### PR TITLE
Update peanut entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If items here need reflashing to work with Home Assistant, please state that in 
 | [GE 45856GE Zigbee Smart Switch In-Wall Lighting Control](https://smile.amazon.com/gp/product/B019HTH2A0/) | In-wall switch. | Requires a neutral wire. ||
 | [Samsung SmartThings Motion Sensor](https://smile.amazon.com/gp/product/B01IE35PCC) | Detects temperature and motion. ||
 | [Samsung SmartThings Water Sensor](https://smile.amazon.com/gp/product/B07F951JDP) | A cheap small water sensor. Reports wet/dry status for the zone. ||
-| [Securifi Peanut Smart Plug](https://smile.amazon.com/gp/product/B00TC9NC82) | Small cheap smart plug with controllable power switch. | Reliable cheap smart plug. Claims to also monitor the energy consumption of the plugged-in device, but monitoring doesn't work. |
+| [Securifi Peanut Smart Plug](https://smile.amazon.com/gp/product/B00TC9NC82) | Small cheap smart plug with controllable power switch. | Reliable cheap smart plug. Claims to also monitor the energy consumption of the plugged-in device, but monitoring doesn't work. These are just big enough that you can't put two of them on the same double outlet. |
 
 ## Z-Wave
 


### PR DESCRIPTION
# Description

You can't put two peanuts on one outlet, update entry accordingly.

<!---
Notes suggestions:

- It is ok to add a link to a device that doesn't work - just add it in the non-working devices section to warn off other users from buying it.
- If the device you're adding in your PR won't work in a local-only mode, please say so in the **Notes** column of your entry.
- If it requires a remote service, definitely note that - I prefer to not buy anything that will brick if the vendor goes out of business or decides to cancel the product line, or even if your internet is just having an outage.
- If it tries to phone home - note that too.
- If you have to reflash a device to get it working with Home Assistant, please add that to the **Notes** column.
- If you need to add a plugin to Home Assistant before it can be used, add that to **Notes** too.
- If it requires the devices connect to an internet server, even just for initial configuration, please add that to **Notes** - I want it easy to see which devices won't brick if the vendor goes out of business and also aren't vulnerable to some jackass hacking the company's servers.
-->
# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post, video or tutorial
- [x] Add/remove a device
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/works-with-home-assistant/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply. Make them look like [x] so that GitHub's markdown renderer renders them properly.
-->

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] Any links to Amazon are to smile.amazon.com so that people can donate to their designated charity when they buy.
- [ ] Any links to any online vendors do _not_ include referral codes.
- [ ] My entries are single lines and are in the appropriate (Hub, Zigbee, Z-Wave, or WIFI) section, and in alphabetical order in their section.
- [x] I have read the [Contributing](https://github.com/unixorn/works-with-home-assistant/blob/master/Contributing.md) document.
- [x] All new and existing tests passed.
- [x] I have personally used the device(s) being added.
