### PR TITLE
Update awesomebot to ignore 50? return codes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,11 +32,11 @@ Notes suggestions:
 Go over all the following points, and put an `x` in all the boxes that apply. Make them look like [x] so that GitHub's markdown renderer renders them properly.
 -->
 
+- [ ] All new and existing tests passed.
 - [ ] I have confirmed that the link(s) in my PR are valid.
 - [ ] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off your commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
 - [ ] Any links to Amazon are to smile.amazon.com so that people can automatically donate to their designated charity when they buy using the link.
 - [ ] Any links to any online vendors do _not_ include referral codes.
 - [ ] Entries are single lines and are in the appropriate (Hub, Zigbee, Z-Wave, or WIFI) section, and in alphabetical order in their section.
 - [ ] I have read the [Contributing](https://github.com/unixorn/works-with-home-assistant/blob/master/Contributing.md) document.
-- [ ] All new and existing tests passed.
 - [ ] I have personally used the device(s) being added.

--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -15,4 +15,4 @@ jobs:
     - uses: actions/checkout@v1
     - uses: docker://dkhamsing/awesome_bot:latest
       with:
-        args: /github/workspace/README.md --request-delay 1 --allow-dupe --allow-redirect --white-list https://ipfs.io,slideshare,https://img.shields.io,https://codeclimate.com/github/unixorn/works-with-home-assistant,https://www.concourse.ci,https://smile.amazon.com,https://inovelli.com/black-series-dimmer-switch-z-wave
+        args: /github/workspace/README.md --request-delay 1 --allow 502,503,504,509,521 --allow-dupe --allow-redirect --white-list https://ipfs.io,slideshare,https://img.shields.io,https://codeclimate.com/github/unixorn/works-with-home-assistant,https://www.concourse.ci,https://smile.amazon.com,https://inovelli.com/black-series-dimmer-switch-z-wave


### PR DESCRIPTION
# Description

- Amazon sometimes returns 50? even for valid product pages, causing false failures on the awesomebot GH action.
- Update checklist order in PR template

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post, video or tutorial
- [ ] Add/remove/update a device entry
- [ ] Text cleanups/typo fixes
- [x] Configuration tweaks

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/works-with-home-assistant/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply. Make them look like [x] so that GitHub's markdown renderer renders them properly.
-->

- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off your commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [ ] Any links to Amazon are to smile.amazon.com so that people can automatically donate to their designated charity when they buy using the link.
- [ ] Any links to any online vendors do _not_ include referral codes.
- [ ] Entries are single lines and are in the appropriate (Hub, Zigbee, Z-Wave, or WIFI) section, and in alphabetical order in their section.
- [ ] I have read the [Contributing](https://github.com/unixorn/works-with-home-assistant/blob/master/Contributing.md) document.
- [ ] All new and existing tests passed.
- [ ] I have personally used the device(s) being added.
