### PR TITLE
Add Xenon smart power strip (UK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ If items here need reflashing to work with Home Assistant, please state that in 
 | Smart Bulb | eWeLight | [Model ZB-CL01 Smart Bulb](https://smile.amazon.com/gp/product/B08QC9P49G/) | RGB bulb, recognized by ZHA.  "Warm" color isn't really warm enough IMO.  Multi-color stuff is fine. |
 | Smart Plug | Securifi | [Peanut Smart Plug](https://smile.amazon.com/gp/product/B00TC9NC82) | A small cheap smart plug with controllable power switch. Reliable cheap smart plug. Claims to also monitor the energy consumption of the plugged-in device, but monitoring doesn't work. These are just big enough that you can't put two of them on the same standard double US outlet. |
 | Smart Plug | Sonoff | [S31 Lite zb](https://sonoff.tech/product/smart-plugs/s31-lite-zb/) | Smart Outlet/Plug, recognized by ZHA. Does not report energy usage. The LEDs are way too bright and cannot be adjusted AFAIK. |
-| Smart Switch (In wall) | GE | [45856GE Smart Switch In-Wall Lighting Control](https://smile.amazon.com/gp/product/B019HTH2A0/) | Requires a neutral wire |
+| Smart Power Strip (UK) | Xenon | [Xenon Smart Power Strip](https://smile.amazon.co.uk/gp/product/B09B3PZK5P) | 4 individually controllable AC sockets + 2 USB sockets that are controlled together. |
+| Smart Switch (In wall) | GE | [45856GE Smart Switch In-Wall Lighting Control](https://smile.amazon.com/gp/product/B019HTH2A0/) | Requires a neutral wire. |
 
 ## Z-Wave
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

Add Xenon power strip. Closes #81.

<!---
Notes suggestions:

- It is ok to add a link to a device that doesn't work - just add it in the non-working devices section to warn off other users from buying it.
- If the device you're adding in your PR won't work in a local-only mode, please say so in the **Notes** column of your entry.
- If it requires a remote service, definitely note that - I prefer to not buy anything that will brick if the vendor goes out of business or decides to cancel the product line, or even if your internet is just having an outage.
- If it tries to phone home - note that too.
- If you have to reflash a device to get it working with Home Assistant, please add that to the **Notes** column. Ideally add a link to the reflash instructions for the device
- If you need to add a plugin to Home Assistant before it can be used, add that to **Notes** too.
- If it requires the devices connect to an internet server, even just for initial configuration, please add that to **Notes** - I want it easy to see which devices won't brick if the vendor goes out of business and also aren't vulnerable to some jackass hacking the company's servers.
-->
# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post, video or tutorial
- [x] Add/remove/update a device entry
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/works-with-home-assistant/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply. Make them look like [x] so that GitHub's markdown renderer renders them properly.
-->

- [x] **I have personally used the device(s), tools or utilities being added.**
- [ ] **If this device, tool or utility requires an internet server to operate or be configured, it is noted in the entry.** Warn people that it could brick if the company shuts down like Insteon did.
- [x] I have read the [Contributing](https://github.com/unixorn/works-with-home-assistant/blob/master/Contributing.md) document.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off your commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] All new and existing tests passed.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] Any links to Amazon are to smile.amazon.com so that people can automatically donate to their designated charity when they buy using the link.
- [ ] Any links to any online vendors do _not_ include referral codes or embedded tracking codes.
- [x] Entries are single lines and are in the appropriate (Hub, Zigbee, Z-Wave, Tools or WIFI) section, and in alphabetical order in their section.
